### PR TITLE
Fix snmp version bug for Beta

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -28,6 +28,9 @@ def post_event_data(endpoint, token, host, variables_binds, index, one_time_flag
         "Authorization": f"Splunk {token}"
     }
 
+    if "NoSuchInstance" in str(variables_binds):
+        variables_binds = "error: " + str(variables_binds)
+
     data = {
         "sourcetype": "sc4snmp:meta",
         "host": host,

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -88,7 +88,7 @@ def mib_string_handler(snmp_engine, host, port, version, community, mib_file, mi
     try:
         errorIndication, errorStatus, errorIndex, varBinds = next(
             getCmd(snmp_engine,
-                CommunityData(community, mpModel=0),
+                CommunityData(community, mpModel=1),
                 UdpTransportTarget((host, port)),
                 ContextData(),
                 ObjectType(ObjectIdentity(mib_file, mib_name, mib_index)).resolveWithMib(mibViewController))               
@@ -120,7 +120,7 @@ def get_handler(snmp_engine, community, host, port, profile, mib_server_url, hec
     """
     errorIndication, errorStatus, errorIndex, varBinds = next(
     getCmd(snmp_engine,
-        CommunityData(community, mpModel=0),
+        CommunityData(community, mpModel=1),
         UdpTransportTarget((host, port)),
         ContextData(),
         ObjectType(ObjectIdentity(profile)))
@@ -146,7 +146,7 @@ def walk_handler(snmp_engine, community, host, port, profile, mib_server_url, he
     """
     for (errorIndication,errorStatus,errorIndex,varBinds) in nextCmd(
         snmp_engine,
-        CommunityData(community),
+        CommunityData(community, mpModel=1),
         UdpTransportTarget((host, port)),
         ContextData(),
         ObjectType(ObjectIdentity(profile[:-2])),lexicographicMode=False):

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -213,6 +213,6 @@ def parse_port(host):
         host = tmp[0]
         port = tmp[1]
     else:
-        port = 1161
+        port = 161
     return host, port
 


### PR DESCRIPTION
Beta release requires support SNMP v2c, corrected the `mpModel` param to support SNMP v2c instead of SNMP v1

mpModel: :py:class:`int`
        SNMP message processing model AKA SNMP version. Known SNMP versions are:
        * `0` - for SNMP v1
        * `1` - for SNMP v2c (default)