### PR TITLE
fix: changed the default mib index to be 1

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -68,7 +68,7 @@ def snmp_polling(host, version, community, profile, server_config, one_time_flag
                         if isinstance(varbind, list):
                             # Perform SNMP polling for mib string
                             try:
-                                mib_index = 0
+                                mib_index = 1
                                 if len(varbind) == 3:
                                     mib_index = varbind[2]
                                 mib_string_handler(


### PR DESCRIPTION
Changed the default mib index to be 1 instead of 0 when handling MIB String