### PR TITLE
Fix/handle mib string without mibindex

### DIFF
--- a/.github/workflows/agreements.yaml
+++ b/.github/workflows/agreements.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Alpha Release
-        uses: cla-assistant/github-action@v2.3.1-beta
+        uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -131,10 +131,10 @@ jobs:
         uses: snyk/actions/python-3.8@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
+      # - name: Upload result to GitHub Code Scanning
+      #   uses: github/codeql-action/upload-sarif@v1
+      #   with:
+      #     sarif_file: snyk.sarif
   build:
     name: Build Release
     needs:
@@ -210,10 +210,10 @@ jobs:
         with:
           image: ${{ fromJSON(steps.docker_meta.outputs.json).tags[0] }}
           args: --file=Dockerfile
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
+      # - name: Upload result to GitHub Code Scanning
+      #   uses: github/codeql-action/upload-sarif@v1
+      #   with:
+      #     sarif_file: snyk.sarif
 
       - uses: actions/download-artifact@v2
         with:

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -151,7 +151,7 @@ def mib_string_handler(
                 mib_string[0], mib_string[1], mib_string[2]
             ).resolveWithMib(mibViewController)
             oid = str(oid)
-            logger.info(f"[-] oid: {oid}")
+            logger.debug(f"[-] oid: {oid}")
 
             # call snmpget
             get_handler(

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -191,8 +191,9 @@ def mib_string_handler(
             )
 
         else:
-            logger.error("Please provide a valid mib string in the correct format")
-            raise Exception("lease provide a valid mib string in the correct format")
+            raise Exception(
+                f"Invalid mib string - {mib_string}. Please provide a valid mib string in the correct format."
+            )
     except Exception as e:
         logger.error(f"Error happened while polling for mib string: {mib_string}: {e}")
 

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -20,9 +20,19 @@ logger = get_task_logger(__name__)
 import json
 import os
 from pysmi import debug as pysmi_debug
-from pysnmp.hlapi import *
+
+# from pysnmp.hlapi import *
+from pysnmp.hlapi import (
+    CommunityData,
+    ContextData,
+    getCmd,
+    nextCmd,
+    UdpTransportTarget,
+    UsmUserData,
+)
 from pysnmp.proto import rfc1902
 from pysnmp.smi import builder, compiler, view
+from pysnmp.smi.rfc1902 import ObjectIdentity, ObjectType
 from splunk_connect_for_snmp_poller.manager.const import (
     AuthProtocolMap,
     PrivProtocolMap,

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -192,7 +192,7 @@ def mib_string_handler(
 
         else:
             raise Exception(
-                f"Invalid mib string - {mib_string}. Please provide a valid mib string in the correct format."
+                f"Invalid mib string - {mib_string}. Please provide a valid mib string in the correct format. Learn more about the format at https://bit.ly/3qtqzQc"
             )
     except Exception as e:
         logger.error(f"Error happened while polling for mib string: {mib_string}: {e}")

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -17,19 +17,18 @@ from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)
 
-from splunk_connect_for_snmp_poller.manager.mib_server_client import get_translation
-from splunk_connect_for_snmp_poller.manager.hec_sender import post_data_to_splunk_hec
+import json
+import os
+from pysmi import debug as pysmi_debug
+from pysnmp.hlapi import *
+from pysnmp.proto import rfc1902
+from pysnmp.smi import builder, compiler, view
 from splunk_connect_for_snmp_poller.manager.const import (
     AuthProtocolMap,
     PrivProtocolMap,
 )
-from pysnmp.hlapi import *
-from pysnmp.proto import rfc1902
-import json
-import os
-
-from pysnmp.smi import builder, view, compiler
-from pysmi import debug as pysmi_debug
+from splunk_connect_for_snmp_poller.manager.hec_sender import post_data_to_splunk_hec
+from splunk_connect_for_snmp_poller.manager.mib_server_client import get_translation
 
 pysmi_debug.setLogger(pysmi_debug.Debug("compiler"))
 

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -194,7 +194,7 @@ def mib_string_handler(
             logger.error("Please provide a valid mib string in the correct format")
             raise Exception("lease provide a valid mib string in the correct format")
     except Exception as e:
-        logger.error(f"Error happened while polling by mib name: {e}")
+        logger.error(f"Error happened while polling for mib string: {mib_string}: {e}")
 
 
 def get_handler(

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -13,13 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from celery.utils.log import get_task_logger
-
-logger = get_task_logger(__name__)
-
 import json
 import os
 
+from celery.utils.log import get_task_logger
 from pysmi import debug as pysmi_debug
 from pysnmp.hlapi import (
     CommunityData,
@@ -44,6 +41,7 @@ from splunk_connect_for_snmp_poller.manager.mib_server_client import (
 )
 
 pysmi_debug.setLogger(pysmi_debug.Debug("compiler"))
+logger = get_task_logger(__name__)
 
 
 # TODO remove the debugging statement later
@@ -204,7 +202,11 @@ def mib_string_handler(
 
         else:
             raise Exception(
-                f"Invalid mib string - {mib_string}. Please provide a valid mib string in the correct format. Learn more about the format at https://bit.ly/3qtqzQc"
+                (
+                    f"Invalid mib string - {mib_string}."
+                    f"\nPlease provide a valid mib string in the correct format. "
+                    f"Learn more about the format at https://bit.ly/3qtqzQc"
+                )
             )
     except Exception as e:
         logger.error(f"Error happened while polling for mib string: {mib_string}: {e}")
@@ -442,7 +444,12 @@ def build_authData(version, community, server_config):
                     "securityName", None
                 )
             logger.debug(
-                f"=============\ncommunityName - {communityName}, communityIndex - {communityIndex}, contextEngineId - {contextEngineId}, contextName - {contextName}, tag - {tag}, securityName - {securityName}"
+                f"\ncommunityName - {communityName}, "
+                f"communityIndex - {communityIndex}, "
+                f"contextEngineId - {contextEngineId}, "
+                f"contextName - {contextName}, "
+                f"tag - {tag}, "
+                f"securityName - {securityName}"
             )
         except Exception as e:
             logger.error(

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -19,16 +19,15 @@ logger = get_task_logger(__name__)
 
 import json
 import os
-from pysmi import debug as pysmi_debug
 
-# from pysnmp.hlapi import *
+from pysmi import debug as pysmi_debug
 from pysnmp.hlapi import (
     CommunityData,
     ContextData,
-    getCmd,
-    nextCmd,
     UdpTransportTarget,
     UsmUserData,
+    getCmd,
+    nextCmd,
 )
 from pysnmp.proto import rfc1902
 from pysnmp.smi import builder, compiler, view
@@ -37,8 +36,12 @@ from splunk_connect_for_snmp_poller.manager.const import (
     AuthProtocolMap,
     PrivProtocolMap,
 )
-from splunk_connect_for_snmp_poller.manager.hec_sender import post_data_to_splunk_hec
-from splunk_connect_for_snmp_poller.manager.mib_server_client import get_translation
+from splunk_connect_for_snmp_poller.manager.hec_sender import (
+    post_data_to_splunk_hec,
+)
+from splunk_connect_for_snmp_poller.manager.mib_server_client import (
+    get_translation,
+)
 
 pysmi_debug.setLogger(pysmi_debug.Debug("compiler"))
 

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -81,18 +81,13 @@ def snmp_polling(
                         if isinstance(varbind, list):
                             # Perform SNMP polling for mib string
                             try:
-                                mib_index = 1
-                                if len(varbind) == 3:
-                                    mib_index = varbind[2]
                                 mib_string_handler(
                                     snmp_engine,
                                     auth_data,
                                     context_data,
                                     host,
                                     port,
-                                    varbind[0],
-                                    varbind[1],
-                                    mib_index,
+                                    varbind,
                                     mib_server_url,
                                     index,
                                     otel_logs_url,

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -16,7 +16,10 @@
 import os
 import threading
 from celery.utils.log import get_task_logger
-from pysnmp.hlapi import *
+
+# from pysnmp.hlapi import *
+from pysnmp.hlapi import SnmpEngine
+
 from splunk_connect_for_snmp_poller.manager.celery_client import app
 from splunk_connect_for_snmp_poller.manager.hec_sender import post_data_to_splunk_hec
 from splunk_connect_for_snmp_poller.manager.task_utilities import (

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -13,23 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from celery.utils.log import get_task_logger
-
 import os
+import threading
+from celery.utils.log import get_task_logger
+from pysnmp.hlapi import *
 from splunk_connect_for_snmp_poller.manager.celery_client import app
 from splunk_connect_for_snmp_poller.manager.hec_sender import post_data_to_splunk_hec
 from splunk_connect_for_snmp_poller.manager.task_utilities import (
-    get_handler,
-    walk_handler,
-    mib_string_handler,
-    parse_port,
     build_authData,
     build_contextData,
+    get_handler,
+    mib_string_handler,
+    parse_port,
+    walk_handler,
 )
-from pysnmp.hlapi import *
-import os
-
-import threading
 
 # Used to store a single SnmpEngine() instance for each Celery task
 thread_local = threading.local()

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -15,13 +15,10 @@
 #
 import os
 import threading
+
 from celery.utils.log import get_task_logger
-
-# from pysnmp.hlapi import *
 from pysnmp.hlapi import SnmpEngine
-
 from splunk_connect_for_snmp_poller.manager.celery_client import app
-from splunk_connect_for_snmp_poller.manager.hec_sender import post_data_to_splunk_hec
 from splunk_connect_for_snmp_poller.manager.task_utilities import (
     build_authData,
     build_contextData,


### PR DESCRIPTION
- handle mib string without mib index as a snmpwalk instead of using a default index. 
- e.g for ["SNMPv2-MIB", "sysORID"], we will trigger a snmpwalk to get all index of ["SNMPv2-MIB", "sysORID"]
-  ["SNMPv2-MIB", "sysORID", 1], ["SNMPv2-MIB", "sysORID", 2]...