### PR TITLE
fix: change the way of creating host name which is an id in the database

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/poller_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/poller_utilities.py
@@ -24,6 +24,7 @@ from splunk_connect_for_snmp_poller.manager.realtime.oid_constant import OidCons
 from splunk_connect_for_snmp_poller.manager.realtime.real_time_data import (
     should_redo_walk,
 )
+from splunk_connect_for_snmp_poller.manager.task_utilities import parse_port
 from splunk_connect_for_snmp_poller.manager.tasks import snmp_polling
 from splunk_connect_for_snmp_poller.manager.validator.inventory_validator import (
     is_valid_inventory_line_from_dict,
@@ -132,7 +133,10 @@ def _update_mongo(
     all_walked_hosts_collection, host, host_already_walked, current_sys_up_time
 ):
     if not host_already_walked:
-        all_walked_hosts_collection.add_host(host)
+        _host, _port = parse_port(host)
+        host_to_add = f"{_host}:{_port}"
+        logger.info(f"Adding host: {host_to_add} into Mongo database")
+        all_walked_hosts_collection.add_host(host_to_add)
     all_walked_hosts_collection.update_real_time_data_for(host, current_sys_up_time)
 
 


### PR DESCRIPTION
This is the fix of following issue. 
In the database we store data with host _id of structure -> ip_address:port
For now we save two things to mongo, MIB-REAL-TIME-DATA and MIB-STATIC-DATA. It looks like:
`{ 
    "_id" : "127.0.0.1:161", 
    "MIB-REAL-TIME-DATA" : {
        "1.3.6.1.2.1.1.3.0" : {
            "value" : "125535155", 
            "type" : "TimeTicks"
        }
    }, 
    "MIB-STATIC-DATA" : {
        "IF-MIB" : [
            {
                "interface_index" : [
                    "1", 
                    "2"
                ]
            }, 
            {
                "interface_desc" : [
                    "lo", 
                    "eth0"
                ]
            }
        ]
    }
}`
During first walk operation, firstly host id is being added along with MIB-REAL-TIME-DATA. In case of enricher presence MIB-STATIC-DATA is inserted to the "ip_address:port" structured host id which - we assume - exists.
But in scheduler-inventory.yml host with or without port can be provided. In case user typed bare ip address, in mongo db id was exactly the same:
`{ 
    "_id" : "127.0.0.1", 
`
and then in enrichment phase we encountered problem with absent hostname "127.0.0.1:161".
