### PR TITLE
Fix/error with no snmp received before timeout

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -50,16 +50,11 @@ class HecSender:
 
     @staticmethod
     def send_request(endpoint, data):
-        try:
-            logger.debug("+++++++++endpoint+++++++++\n%s", endpoint)
-            response = requests.post(url=endpoint, json=data, timeout=60)
-            logger.debug("Response code is %s", response.status_code)
-            logger.debug("Response is %s", response.text)
-            return response
-        except requests.ConnectionError as e:
-            logger.error(
-                f"Connection error when sending data to HEC index - {data['index']}: {e}"
-            )
+        logger.debug("+++++++++endpoint+++++++++\n%s", endpoint)
+        response = requests.post(url=endpoint, json=data, timeout=60)
+        logger.debug("Response code is %s", response.status_code)
+        logger.debug("Response is %s", response.text)
+        return response
 
 
 def post_data_to_splunk_hec(

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -55,7 +55,7 @@ class HecSender:
         logger.debug("Response code is %s", response.status_code)
         logger.debug("Response is %s", response.text)
         logger.info(f"data: {data}")
-        if data.get("sourcetype") == "sc4snmp:error":
+        if data.get("sourcetype", "") == "sc4snmp:error":
             raise Exception("Error happened during snmp pooling")
         return response
 

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -54,7 +54,8 @@ class HecSender:
         response = requests.post(url=endpoint, json=data, timeout=60)
         logger.debug("Response code is %s", response.status_code)
         logger.debug("Response is %s", response.text)
-        if data["sourcetype"] == "sc4snmp:error":
+        logger.info(f"data: {data}")
+        if data.get("sourcetype") == "sc4snmp:error":
             raise Exception("Error happened during snmp pooling")
         return response
 

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -50,14 +50,16 @@ class HecSender:
 
     @staticmethod
     def send_request(endpoint, data):
-        logger.debug("+++++++++endpoint+++++++++\n%s", endpoint)
-        response = requests.post(url=endpoint, json=data, timeout=60)
-        logger.debug("Response code is %s", response.status_code)
-        logger.debug("Response is %s", response.text)
-        logger.info(f"data: {data}")
-        if data.get("sourcetype", "") == "sc4snmp:error":
-            raise Exception("Error happened during snmp pooling")
-        return response
+        try:
+            logger.debug("+++++++++endpoint+++++++++\n%s", endpoint)
+            response = requests.post(url=endpoint, json=data, timeout=60)
+            logger.debug("Response code is %s", response.status_code)
+            logger.debug("Response is %s", response.text)
+            return response
+        except requests.ConnectionError as e:
+            logger.error(
+                f"Connection error when sending data to HEC index - {data['index']}: {e}"
+            )
 
 
 def post_data_to_splunk_hec(

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -55,8 +55,8 @@ class HecSender:
         logger.debug("Response code is %s", response.status_code)
         logger.debug("Response is %s", response.text)
         logger.info(f"data: {data}")
-        if data.get("sourcetype", "") == "sc4snmp:error":
-            raise Exception("Error happened during snmp pooling")
+        # if data.get("sourcetype", "") == "sc4snmp:error":
+        #     raise Exception("Error happened during snmp pooling")
         return response
 
 

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -54,6 +54,8 @@ class HecSender:
         response = requests.post(url=endpoint, json=data, timeout=60)
         logger.debug("Response code is %s", response.status_code)
         logger.debug("Response is %s", response.text)
+        if "error" in data:
+            raise Exception("Error happened during snmp pooling")
         return response
 
 

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -55,8 +55,8 @@ class HecSender:
         logger.debug("Response code is %s", response.status_code)
         logger.debug("Response is %s", response.text)
         logger.info(f"data: {data}")
-        # if data.get("sourcetype", "") == "sc4snmp:error":
-        #     raise Exception("Error happened during snmp pooling")
+        if data.get("sourcetype", "") == "sc4snmp:error":
+            raise Exception("Error happened during snmp pooling")
         return response
 
 

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -54,7 +54,7 @@ class HecSender:
         response = requests.post(url=endpoint, json=data, timeout=60)
         logger.debug("Response code is %s", response.status_code)
         logger.debug("Response is %s", response.text)
-        if "error" in data:
+        if data["sourcetype"] == "sc4snmp:error":
             raise Exception("Error happened during snmp pooling")
         return response
 

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -212,7 +212,6 @@ async def snmp_polling_async(
                     *get_bulk_specific_parameters, *static_parameters, prepared_profile  # type: ignore
                 )
 
-        raise Exception("Random exception to test if it fixes rabbitmq")
     except Exception:
         logger.exception(
             f"Error occurred while executing SNMP polling for {host}, version={ir.version}, profile={ir.profile}"

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -117,7 +117,7 @@ def sort_varbinds(varbind_list: list) -> VarbindCollection:
 
 
 # TODO remove the debugging statement later
-@app.task(max_retries=1)
+@app.task(ignore_result=True)
 def snmp_polling(ir_json: str, server_config, index, one_time_flag=False):
     ir = InventoryRecord.from_json(ir_json)
 

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -212,7 +212,7 @@ async def snmp_polling_async(
                     *get_bulk_specific_parameters, *static_parameters, prepared_profile  # type: ignore
                 )
 
-    except Exception as e:
-        logger.error(
-            f"Error occurred while executing SNMP polling for {host}, version={ir.version}, profile={ir.profile}: {e}"
+    except Exception:
+        logger.exception(
+            f"Error occurred while executing SNMP polling for {host}, version={ir.version}, profile={ir.profile}"
         )

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -212,6 +212,7 @@ async def snmp_polling_async(
                     *get_bulk_specific_parameters, *static_parameters, prepared_profile  # type: ignore
                 )
 
+        raise Exception("Random exception to test if it fixes rabbitmq")
     except Exception:
         logger.exception(
             f"Error occurred while executing SNMP polling for {host}, version={ir.version}, profile={ir.profile}"

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -117,7 +117,7 @@ def sort_varbinds(varbind_list: list) -> VarbindCollection:
 
 
 # TODO remove the debugging statement later
-@app.task
+@app.task(max_retries=1)
 def snmp_polling(ir_json: str, server_config, index, one_time_flag=False):
     ir = InventoryRecord.from_json(ir_json)
 


### PR DESCRIPTION
# Description

Recently we found the following celery issue:
Even though scheduler sends correct OID after modification of config file, worker is still executing previous tasks. 

I used this post while fixing bug:
https://stackoverflow.com/questions/30327670/rabbitmq-queued-messages-keep-increasing

Fixes # ADDON-43262

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Configure certain OID, upgrade HELM/apply new config and check if scheduler sends it to worker and if worker executes it
2. Comment out previous change, upgrade HELM/apply new config and check if scheduler stopped sending anything to worker and if worker is idle
3. Configure OID on host that doesn't exist or where SNMPD is not enabled, upgrade HELM/apply new config and check if scheduler sends  it to worker and if worker sends errors to Splunk
4. Comment out previous change, upgrade HELM/apply new config and check if scheduler stopped sending anything to worker and if worker is idle

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings