### PR TITLE
fix: fix for "error with no snmp received before timeout" infinite loop

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -413,6 +413,7 @@ async def snmp_bulk_handler(
                     additional_metric_fields,
                     one_time_flag,
                 )
+            break
 
 
 async def walk_handler(


### PR DESCRIPTION
# Description

This is the fix for an infinite loop present during bulk request

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

1. Create config with bulk on wrong host or stopped snmpd
2. Check if it's being sent to Splunk
3. Change inventory config to something else
4. Check if previous error are not being sent to splunk

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings