### PR TITLE
fix: add some restrictions for getting profiles from mib server

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/poller_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/poller_utilities.py
@@ -32,6 +32,7 @@ from splunk_connect_for_snmp_poller.manager.validator.inventory_validator import
     is_valid_inventory_line_from_dict,
     should_process_inventory_line,
 )
+from splunk_connect_for_snmp_poller.utilities import multi_key_lookup
 
 logger = logging.getLogger(__name__)
 
@@ -82,16 +83,14 @@ def parse_inventory_file(inventory_file_path, profiles):
 
 
 def get_frequency(agent, profiles, default_frequency):
-    if (
-        profiles
-        and "profile" in agent
-        and agent["profile"] != "*"
-        and agent["profile"] in profiles["profiles"]
-    ):
-        return profiles["profiles"][agent["profile"]]["frequency"]
-    else:
-        logger.debug(f'Default frequency was assigned for agent = {agent.get("host")}')
-        return default_frequency
+    if "profile" in agent:
+        frequency = multi_key_lookup(
+            profiles, ("profiles", agent["profile"], "frequency")
+        )
+        if frequency:
+            return frequency
+    logger.debug(f'Default frequency was assigned for agent = {agent.get("host")}')
+    return default_frequency
 
 
 def _extract_sys_uptime_instance(

--- a/splunk_connect_for_snmp_poller/manager/profile_matching.py
+++ b/splunk_connect_for_snmp_poller/manager/profile_matching.py
@@ -49,8 +49,8 @@ def get_profiles(server_config):
 
     result = {}
     merged_profiles = {}
-
-    merged_profiles.update(mib_profiles["profiles"])
+    if "profiles" in mib_profiles:
+        merged_profiles.update(mib_profiles["profiles"])
     merged_profiles.update(server_config["profiles"])
 
     result["profiles"] = merged_profiles

--- a/tests/test_poller_utilities.py
+++ b/tests/test_poller_utilities.py
@@ -77,3 +77,15 @@ class TestPollerUtilities(TestCase):
         profiles = {"profiles": {"some_profile": {"frequency": 20}}}
         result = get_frequency(agent, profiles, 60)
         self.assertEqual(result, 60)
+
+    def test_return_default_frequency_when_frequency_is_missing(self):
+        agent = {"profile": "some_profile"}
+        profiles = {"profiles": {"some_profile_2": {}}}
+        result = get_frequency(agent, profiles, 60)
+        self.assertEqual(result, 60)
+
+    def test_return_default_frequency_when_there_is_no_profiles(self):
+        agent = {"profile": "some_profile"}
+        profiles = {"profiles": {}}
+        result = get_frequency(agent, profiles, 60)
+        self.assertEqual(result, 60)


### PR DESCRIPTION
# Description

A new bug from profile matching feature appeared:

```
2021-10-11 14:42:01,367 | splunk_connect_for_snmp_poller.manager.poller | DEBUG | Adding configuration for job 10.202.9.217#1.3.6.1.2.1.2.2.*
Traceback (most recent call last):
  File "/usr/local/bin/sc4snmp-poller", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/snmp_poller_server.py", line 34, in main
    poller_server.run()
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/manager/poller.py", line 72, in run
    self.__check_inventory()
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/manager/poller.py", line 94, in __check_inventory
    for ir in parse_inventory_file(self._args.inventory, profiles):
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/manager/poller_utilities.py", line 78, in parse_inventory_file
    get_frequency(agent, profiles, 60),
  File "/usr/local/lib/python3.8/site-packages/splunk_connect_for_snmp_poller/manager/poller_utilities.py", line 91, in get_frequency
    return profiles["profiles"][agent["profile"]]["frequency"]
KeyError: 'frequency'
```

Fixes # not yet created

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Run unit tests.
To reproduce the issue  it's enough to run an installation with new develop image.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings