### PR TITLE
feat: force inventory refresh

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -93,8 +93,11 @@ class Poller:
 
         # update job when either inventory changes or config changes
         if server_config_modified or inventory_config_modified or self._force_refresh:
-            logger.info("Refreshing inventory and config")
             self._force_refresh = False
+            logger.info(f"Refreshing inventory and config: server_config_modified = {server_config_modified}, "
+                        f"inventory_config_modified = {inventory_config_modified}, "
+                        f"force_refresh = {self._force_refresh}")
+
             inventory_hosts = set()
             profiles = get_profiles(self._server_config)
             for ir in parse_inventory_file(self._args.inventory, profiles):

--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -94,9 +94,11 @@ class Poller:
         # update job when either inventory changes or config changes
         if server_config_modified or inventory_config_modified or self._force_refresh:
             self._force_refresh = False
-            logger.info(f"Refreshing inventory and config: server_config_modified = {server_config_modified}, "
-                        f"inventory_config_modified = {inventory_config_modified}, "
-                        f"force_refresh = {self._force_refresh}")
+            logger.info(
+                f"Refreshing inventory and config: server_config_modified = {server_config_modified}, "
+                f"inventory_config_modified = {inventory_config_modified}, "
+                f"force_refresh = {self._force_refresh}"
+            )
 
             inventory_hosts = set()
             profiles = get_profiles(self._server_config)

--- a/splunk_connect_for_snmp_poller/manager/poller_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/poller_utilities.py
@@ -66,7 +66,7 @@ def refresh_inventory(force_inventory_refresh):
     return schedule.CancelJob
 
 
-def parse_inventory_file(inventory_file_path, profiles):
+def parse_inventory_file(inventory_file_path, profiles, fetch_frequency=True):
     with open(inventory_file_path, newline="") as inventory_file:
         for agent in csv.DictReader(inventory_file, delimiter=","):
             inventory_record = InventoryRecord(
@@ -74,7 +74,7 @@ def parse_inventory_file(inventory_file_path, profiles):
                 agent["version"],
                 agent["community"],
                 agent["profile"],
-                get_frequency(agent, profiles, 60),
+                get_frequency(agent, profiles, 60) if fetch_frequency else None
             )
             if _should_process_current_line(inventory_record):
                 yield inventory_record
@@ -190,7 +190,7 @@ def automatic_realtime_task(
 ):
     try:
         for inventory_record in parse_inventory_file(
-            inventory_file_path, profiles=None
+            inventory_file_path, profiles=None, fetch_frequency=False
         ):
             db_host_id = return_database_id(inventory_record.host)
             sys_up_time = _extract_sys_uptime_instance(

--- a/splunk_connect_for_snmp_poller/manager/poller_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/poller_utilities.py
@@ -74,7 +74,7 @@ def parse_inventory_file(inventory_file_path, profiles, fetch_frequency=True):
                 agent["version"],
                 agent["community"],
                 agent["profile"],
-                get_frequency(agent, profiles, 60) if fetch_frequency else None
+                get_frequency(agent, profiles, 60) if fetch_frequency else None,
             )
             if _should_process_current_line(inventory_record):
                 yield inventory_record

--- a/splunk_connect_for_snmp_poller/manager/poller_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/poller_utilities.py
@@ -16,7 +16,6 @@
 import csv
 import logging.config
 import threading
-from pathlib import Path
 
 import schedule
 from pysnmp.hlapi import ObjectIdentity, ObjectType, UdpTransportTarget, getCmd
@@ -187,7 +186,7 @@ def automatic_realtime_task(
     server_config,
     local_snmp_engine,
     force_inventory_refresh,
-    initial_walk
+    initial_walk,
 ):
     try:
         for inventory_record in parse_inventory_file(
@@ -216,8 +215,7 @@ def automatic_realtime_task(
                 if not initial_walk:
                     # force inventory reloading after 2 min with new walk data
                     schedule.every(2).minutes.do(
-                        refresh_inventory,
-                        force_inventory_refresh
+                        refresh_inventory, force_inventory_refresh
                     )
             _update_mongo(
                 all_walked_hosts_collection,


### PR DESCRIPTION
# Description

Previously we used UNIX touch command to force refresh of inventory but as we have readonly filesystem on Kubernetes I redesigned this feature



## Type of change

Please delete options that are not relevant.


- [x] Refactor/improvement


## How Has This Been Tested?

I placed proper log entry and by updating record in Mongo I tricked our system to issue WALK command and inventory refresh. One need to put bigger value than existing in mongo for sysUpTime to trigger rewalk.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings