### PR TITLE
fix: onetime walk with enricher

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -615,26 +615,6 @@ def _sort_walk_data(
     return result_to_send_to_hec
 
 
-def _return_mib_enricher_for_walk(
-    mongo_connection, hostname, existing_data, additional_data
-):
-    """
-    This function works only when an enricher is specified in the config and walk is being ran.
-    If any data was derived from walk result, then the function updates MongoDB with the result.
-    If no data was derived from the walk, then it's being retrieved from the MongoDB.
-    """
-    if existing_data or additional_data:
-        processed_result = mongo_connection.update_mib_static_data_for(
-            hostname, existing_data, additional_data
-        )
-        return MibEnricher(processed_result)
-    else:
-        processed_data = mongo_connection.static_data_for(hostname)
-        if not processed_data:
-            return None
-        return MibEnricher(processed_data)
-
-
 def parse_port(host):
     """
     @params host: host filed in inventory.csv. e.g 10.202.12.56, 127.0.0.1:1162

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -601,15 +601,15 @@ def _sort_walk_data(
     """
     if is_metric:
         merged_result_metric.append(varbind)
-        result = varbind
+        result_to_send_to_hec = varbind
         merged_result.append(eval(varbind))
     else:
         merged_result_non_metric.append(varbind)
-        result = eval(varbind)
-        metric_part = result["metric"]
+        result_dict = eval(varbind)
+        metric_part = eval(result_dict["metric"])
         merged_result.append(metric_part)
-        result = result["non_metric"]
-    return result
+        result_to_send_to_hec = result_dict["non_metric"]
+    return result_to_send_to_hec
 
 
 def _return_mib_enricher_for_walk(

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -607,7 +607,9 @@ def _sort_walk_data(
     else:
         merged_result_non_metric.append(varbind)
         result_dict = eval(varbind)
-        metric_part = eval(result_dict["metric"])
+        metric_part = result_dict["metric"]
+        if isinstance(metric_part, str):
+            metric_part = eval(metric_part)
         merged_result.append(metric_part)
         result_to_send_to_hec = result_dict["non_metric"]
     return result_to_send_to_hec

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -130,8 +130,11 @@ async def result_without_translation(var_binds, return_multimetric):
             result = json.dumps(result)
         else:
             if return_multimetric:
-                result = '{{"metric": {{"{oid}":"{value}"}}, "non_metric": "{oid}={value}"}}'.format(
-                    oid=name.prettyPrint(), value=val.prettyPrint()
+                result = (
+                    '{{"metric": {{"metric_name": "{oid}", "_value": "{value}"}}, '
+                    '"non_metric": "{oid}={value}"}}'.format(
+                        oid=name.prettyPrint(), value=val.prettyPrint()
+                    )
                 )
             else:
                 result = '{oid}="{value}"'.format(

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -569,6 +569,7 @@ async def walk_handler_with_enricher(
                 one_time_flag,
             )
 
+    logger.info("Walk finished")
     processed_result = extract_network_interface_data_from_walk(enricher, merged_result)
     additional_enricher_varbinds = (
         extract_network_interface_data_from_additional_config(enricher)

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -607,8 +607,6 @@ def _sort_walk_data(
         merged_result_non_metric.append(varbind)
         result = eval(varbind)
         metric_part = result["metric"]
-        if isinstance(metric_part, str):
-            metric_part = eval(metric_part)
         merged_result.append(metric_part)
         result = result["non_metric"]
     return result

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -572,7 +572,7 @@ async def walk_handler_with_enricher(
                 one_time_flag,
             )
 
-    logger.info("Walk finished")
+    logger.info(f"Walk finished for {host} profile={ir.profile}")
     processed_result = extract_network_interface_data_from_walk(enricher, merged_result)
     additional_enricher_varbinds = (
         extract_network_interface_data_from_additional_config(enricher)

--- a/splunk_connect_for_snmp_poller/mongo.py
+++ b/splunk_connect_for_snmp_poller/mongo.py
@@ -182,12 +182,12 @@ class WalkedHostsRepository:
 
     # Input is what extract_network_interface_data_from_walk() returns
     def update_mib_static_data_for(self, host, existing_data, additional_data):
-        logger.info("Updating static data")
         if not existing_data and not additional_data:
             return
         static_data_dictionary = self.create_mib_static_data_mongo_structure(
             existing_data, additional_data
         )
+        logger.info(f"Updating static data for {host} with {static_data_dictionary}")
         self._walked_hosts.find_one_and_update(
             {"_id": host},
             {"$set": static_data_dictionary},

--- a/splunk_connect_for_snmp_poller/mongo.py
+++ b/splunk_connect_for_snmp_poller/mongo.py
@@ -182,6 +182,7 @@ class WalkedHostsRepository:
 
     # Input is what extract_network_interface_data_from_walk() returns
     def update_mib_static_data_for(self, host, existing_data, additional_data):
+        logger.info("Updating static data")
         if not existing_data and not additional_data:
             return
         static_data_dictionary = self.create_mib_static_data_mongo_structure(


### PR DESCRIPTION
# Description

This is the fix of the bug of onetime walk not being run when enricher is on.
The following problems were causing this:
1. Wrong creation of result without translation, it needs to be in a form
`{"metric": .., "non_metric"}`
2. In walk with enricher we were running all of the calls and saving results to lists, processing it, adding data to database and then sending all of it to HEC. It was taking a lot of time, so now the workflow is different -> every time we gather the data we send it immediately ro HEC, then save it to list, and when everything was already sent to HEC it is being processed. That means, in sourcetype=snmp:walk we won't have additional dimensions yet, but it shouldn't be any problem for the user, as onetime walk serves for gathering data, not analysis.

Also, ad SNMP WALK serves now only for onetime operation, I deleted a few functions that are no longer needed.

Fixes # ADDON-43432

## Type of change

Please delete options that are not relevant.

- [x] Bug fix


## How Has This Been Tested?

I installed the addon, added one host and checked if the onetime operation was triggered. After it finished I checked if we have MIB-STATIC-DATA in Splunk.
Also, locally I tested it with disabled mib server to check if we have any problems in case of no translation found.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings