### PR TITLE
fix: matching on both dysDescr and sysObjectId

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -251,7 +251,7 @@ class Poller:
                     if realtime_collection:
                         descr = extract_desc(realtime_collection)
 
-                        if descr:
+                        if any(descr):
                             assigned_profiles = assign_profiles_to_device(
                                 profiles["profiles"], descr
                             )

--- a/splunk_connect_for_snmp_poller/manager/profile_matching.py
+++ b/splunk_connect_for_snmp_poller/manager/profile_matching.py
@@ -43,8 +43,9 @@ def assign_profiles_to_device(profiles, device_desc):
 
 def match_profile_with_device(device_desc, profile, profiles, result):
     for pattern in profiles[profile]["patterns"]:
+        compiled = re.compile(pattern)
         for desc in device_desc:
-            if desc and re.compile(pattern).match(desc):
+            if desc and compiled.match(desc):
                 result.append((profile, profiles[profile]["frequency"]))
                 return
 

--- a/splunk_connect_for_snmp_poller/manager/profile_matching.py
+++ b/splunk_connect_for_snmp_poller/manager/profile_matching.py
@@ -30,18 +30,23 @@ def extract_desc(realtime_collection):
     sys_object_id = multi_key_lookup(
         realtime_collection, (OidConstant.SYS_OBJECT_ID, "value")
     )
-    return sys_descr if sys_descr is not None else sys_object_id
+    return sys_descr, sys_object_id
 
 
 def assign_profiles_to_device(profiles, device_desc):
     result = []
     for profile in profiles:
         if "patterns" in profiles[profile]:
-            for pattern in profiles[profile]["patterns"]:
-                if re.compile(pattern).match(device_desc):
-                    result.append((profile, profiles[profile]["frequency"]))
-                    continue
+            match_profile_with_device(device_desc, profile, profiles, result)
     return result
+
+
+def match_profile_with_device(device_desc, profile, profiles, result):
+    for pattern in profiles[profile]["patterns"]:
+        for desc in device_desc:
+            if desc and re.compile(pattern).match(desc):
+                result.append((profile, profiles[profile]["frequency"]))
+                return
 
 
 def get_profiles(server_config):

--- a/tests/test_profile_matching.py
+++ b/tests/test_profile_matching.py
@@ -26,33 +26,39 @@ class TestProfileMatching(TestCase):
         realtime_collection = {OidConstant.SYS_DESCR: {"value": "Linux Suse 1.2.3.4"}}
 
         descr = extract_desc(realtime_collection)
-        self.assertEqual("Linux Suse 1.2.3.4", descr)
+        self.assertEqual(2, len(descr))
+        self.assertEqual("Linux Suse 1.2.3.4", descr[0])
 
     def test_return_sys_object_id(self):
         realtime_collection = {OidConstant.SYS_OBJECT_ID: {"value": "Some object ID"}}
 
         descr = extract_desc(realtime_collection)
-        self.assertEqual("Some object ID", descr)
+        self.assertEqual(2, len(descr))
+        self.assertEqual("Some object ID", descr[1])
 
-    def test_return_sys_desc_when_both_values_are_present(self):
+    def test_return_both_when_both_values_are_present(self):
         realtime_collection = {
             OidConstant.SYS_OBJECT_ID: {"value": "Some object ID"},
             OidConstant.SYS_DESCR: {"value": "Linux Suse 1.2.3.4"},
         }
 
         descr = extract_desc(realtime_collection)
-        self.assertEqual("Linux Suse 1.2.3.4", descr)
+        self.assertEqual(2, len(descr))
+        self.assertEqual("Linux Suse 1.2.3.4", descr[0])
+        self.assertEqual("Some object ID", descr[1])
 
-    def test_return_none_when_no_sysdescr_nor_sys_object_id(self):
+    def test_return_tuple_with_none_values(self):
         realtime_collection = {}
 
         descr = extract_desc(realtime_collection)
-        self.assertIsNone(descr)
+        self.assertEqual(2, len(descr))
+        self.assertIsNone(descr[0])
+        self.assertIsNone(descr[1])
 
     def test_assign_profile_to_device(self):
         profiles = {"zeus": {"patterns": [".*zeus.*"], "frequency": 20}}
 
-        result = assign_profiles_to_device(profiles, "My zeus device")
+        result = assign_profiles_to_device(profiles, ("My zeus device", None))
 
         self.assertEqual(len(result), 1)
         profile, frequency = next(iter(result))
@@ -65,7 +71,24 @@ class TestProfileMatching(TestCase):
             "linux": {"patterns": [".*linux.*"], "frequency": 30},
         }
 
-        result = assign_profiles_to_device(profiles, "My zeus device, linux 2.3.4")
+        result = assign_profiles_to_device(profiles, ("My zeus device, linux 2.3.4", None))
+
+        self.assertEqual(len(result), 2)
+        profile, frequency = result[0]
+        self.assertEqual("zeus", profile)
+        self.assertEqual(frequency, 20)
+
+        profile, frequency = result[1]
+        self.assertEqual("linux", profile)
+        self.assertEqual(frequency, 30)
+
+    def test_assign_multiple_profile_to_device_from_different_descs(self):
+        profiles = {
+            "zeus": {"patterns": [".*zeus.*"], "frequency": 20},
+            "linux": {"patterns": [".*linux.*"], "frequency": 30},
+        }
+
+        result = assign_profiles_to_device(profiles, ("My zeus device", "linux 2.3.4"))
 
         self.assertEqual(len(result), 2)
         profile, frequency = result[0]
@@ -79,6 +102,6 @@ class TestProfileMatching(TestCase):
     def test_no_assignment_when_patterns_are_missing(self):
         profiles = {"zeus": {"frequency": 20}}
 
-        result = assign_profiles_to_device(profiles, "My zeus device")
+        result = assign_profiles_to_device(profiles, ("My zeus device", None))
 
         self.assertEqual(len(result), 0)

--- a/tests/test_profile_matching.py
+++ b/tests/test_profile_matching.py
@@ -71,7 +71,9 @@ class TestProfileMatching(TestCase):
             "linux": {"patterns": [".*linux.*"], "frequency": 30},
         }
 
-        result = assign_profiles_to_device(profiles, ("My zeus device, linux 2.3.4", None))
+        result = assign_profiles_to_device(
+            profiles, ("My zeus device, linux 2.3.4", None)
+        )
 
         self.assertEqual(len(result), 2)
         profile, frequency = result[0]


### PR DESCRIPTION
# Description

Matching is now done on both dysDescr and sysObjectId



## Type of change

Please delete options that are not relevant.

- [x] Bug fix


## How Has This Been Tested?

Run full matching process and confirmed both properties are used for matching

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings