### PR TITLE
fix: onetime walk retry

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -54,9 +54,7 @@ class Poller:
         self._inventory_mod_time = 0
         self._config_mod_time = 0
         self._jobs_map = {}
-        self._mongo_walked_hosts_coll = WalkedHostsRepository(
-            self._server_config["mongo"]
-        )
+        self._mongo = WalkedHostsRepository(self._server_config["mongo"])
         self._local_snmp_engine = SnmpEngine()
         self._unmatched_devices = {}
         self._lock = threading.Lock()
@@ -146,8 +144,8 @@ class Poller:
                 schedule.cancel_job(self._jobs_map.get(entry_key))
                 db_host_id = return_database_id(entry_key)
                 logger.debug("Removing _id %s from mongo database", db_host_id)
-                self._mongo_walked_hosts_coll.delete_host(db_host_id)
-                self._mongo_walked_hosts_coll.delete_onetime_walk_result(db_host_id)
+                self._mongo.delete_host(db_host_id)
+                self._mongo.delete_onetime_walk_result(db_host_id)
                 del self._jobs_map[entry_key]
 
     def update_schedule_for_changed_conf(self, entry_key, ir, profiles):
@@ -206,7 +204,7 @@ class Poller:
         # For debugging purposes better change it to "one second"
         schedule.every(self._args.realtime_task_frequency).seconds.do(
             automatic_realtime_job,
-            self._mongo_walked_hosts_coll,
+            self._mongo,
             self._args.inventory,
             self.__get_splunk_indexes(),
             self._server_config,
@@ -221,7 +219,7 @@ class Poller:
         )
 
         automatic_realtime_job(
-            self._mongo_walked_hosts_coll,
+            self._mongo,
             self._args.inventory,
             self.__get_splunk_indexes(),
             self._server_config,
@@ -231,7 +229,7 @@ class Poller:
         )
         schedule.every(self._args.onetime_task_frequency).minutes.do(
             automatic_onetime_task,
-            self._mongo_walked_hosts_coll,
+            self._mongo,
             self.__get_splunk_indexes(),
             self._server_config,
         )
@@ -254,10 +252,8 @@ class Poller:
                 self._lock.acquire()
                 processed_devices = set()
                 for host, device in self._unmatched_devices.items():
-                    realtime_collection = (
-                        self._mongo_walked_hosts_coll.real_time_data_for(
-                            return_database_id(host)
-                        )
+                    realtime_collection = self._mongo.real_time_data_for(
+                        return_database_id(host)
                     )
                     if realtime_collection:
                         descr = extract_desc(realtime_collection)

--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -78,7 +78,7 @@ class Poller:
         while True:
             if counter == 0:
                 self.__check_inventory()
-                counter = int(self._args.refresh_interval)
+                counter = self._args.refresh_interval
 
             schedule.run_pending()
             time.sleep(1)
@@ -229,14 +229,12 @@ class Poller:
             self.force_inventory_refresh,
             True,
         )
-        logger.info("After automatic_realtime_job single")
         schedule.every(self._args.onetime_task_frequency).minutes.do(
             automatic_onetime_task,
             self._mongo_walked_hosts_coll,
             self.__get_splunk_indexes(),
             self._server_config,
         )
-        logger.info("After automatic_onetime_task")
 
     def add_device_for_profile_matching(self, device: InventoryRecord):
         self._lock.acquire()

--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -147,7 +147,7 @@ class Poller:
                 schedule.cancel_job(self._jobs_map.get(entry_key))
                 db_host_id = return_database_id(entry_key)
                 if db_host_id not in inventory_hosts:
-                    logger.debug(
+                    logger.info(
                         "Removing _id %s from mongo database, it is not in used hosts %s",
                         db_host_id,
                         str(inventory_hosts),

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -164,7 +164,6 @@ async def snmp_polling_async(
         additional_metric_fields,
     ]
     get_bulk_specific_parameters = [mongo_connection, enricher_presence]
-
     try:
         # Perform SNNP Polling for string profile in inventory.csv
         if not is_oid(ir.profile):

--- a/splunk_connect_for_snmp_poller/mongo.py
+++ b/splunk_connect_for_snmp_poller/mongo.py
@@ -112,11 +112,10 @@ class WalkedHostsRepository:
         self._walked_hosts.insert_one({"_id": host})
 
     def get_all_unwalked_hosts(self):
-        return self._unwalked_hosts.find({})
+        return list(self._unwalked_hosts.find({}))
 
     def add_onetime_walk_result(self, host, version, community):
-        logger.info("add_onetime_walk_result")
-        logger.info(host)
+        logger.debug("Add host %s to unwalked_host collection", host)
         self._unwalked_hosts.insert_one(
             {
                 "_id": host,
@@ -127,8 +126,7 @@ class WalkedHostsRepository:
         )
 
     def delete_onetime_walk_result(self, host):
-        logger.info("delete_onetime_walk_result")
-        logger.info(host)
+        logger.debug("Delete host %s from unwalked_host collection", host)
         self._unwalked_hosts.delete_one({"_id": host})
 
     def delete_host(self, host):

--- a/splunk_connect_for_snmp_poller/mongo.py
+++ b/splunk_connect_for_snmp_poller/mongo.py
@@ -92,7 +92,10 @@ class WalkedHostsRepository:
             )
 
         self._walked_hosts = self._client[mongo_config["database"]][
-            mongo_config["collection"]
+            mongo_config["walked_collection"]
+        ]
+        self._unwalked_hosts = self._client[mongo_config["database"]][
+            mongo_config["unwalked_collection"]
         ]
 
     def is_connected(self):
@@ -107,6 +110,26 @@ class WalkedHostsRepository:
 
     def add_host(self, host):
         self._walked_hosts.insert_one({"_id": host})
+
+    def get_all_unwalked_hosts(self):
+        return self._unwalked_hosts.find({})
+
+    def add_onetime_walk_result(self, host, version, community):
+        logger.info("add_onetime_walk_result")
+        logger.info(host)
+        self._unwalked_hosts.insert_one(
+            {
+                "_id": host,
+                "host": host,
+                "version": version,
+                "community": community,
+            }
+        )
+
+    def delete_onetime_walk_result(self, host):
+        logger.info("delete_onetime_walk_result")
+        logger.info(host)
+        self._unwalked_hosts.delete_one({"_id": host})
 
     def delete_host(self, host):
         logger.debug("Delete host %s from walked_host collection", host)

--- a/splunk_connect_for_snmp_poller/utilities.py
+++ b/splunk_connect_for_snmp_poller/utilities.py
@@ -37,6 +37,7 @@ import logging
 import os
 import signal
 import sys
+from enum import Enum
 
 import yaml
 
@@ -109,7 +110,12 @@ def parse_command_line_arguments():
         default=10,
         help="Frequency in seconds for matching task",
     )
-
+    parser.add_argument(
+        "--onetime_task_frequency",
+        type=int,
+        default=120,
+        help="Frequency in seconds for onetime task",
+    )
     return parser.parse_args()
 
 
@@ -141,3 +147,8 @@ def multi_key_lookup(dictionary, tuple_of_keys):
         return reduce(dict.get, tuple_of_keys, dictionary)
     except TypeError:
         return None
+
+
+class OnetimeFlag(str, Enum):
+    FIRST_WALK = "first_time"
+    AFTER_FAIL = "after_fail"

--- a/splunk_connect_for_snmp_poller/utilities.py
+++ b/splunk_connect_for_snmp_poller/utilities.py
@@ -85,7 +85,11 @@ def parse_command_line_arguments():
         "-i", "--inventory", default="inventory.csv", help="Inventory Config File"
     )
     parser.add_argument(
-        "-r", "--refresh_interval", default="1", help="Refresh Interval of Inventory"
+        "-r",
+        "--refresh_interval",
+        type=int,
+        default=1,
+        help="Refresh Interval of Inventory",
     )
     parser.add_argument(
         "--event_index", default="##EVENTS_INDEX##", help="Event index for polling data"


### PR DESCRIPTION
# Description

If snmp simulator is down, then onetime walk fails. We need data from onetime_walk for enricher to work. This PR adds retries for onetime_walk.

Fixes # 43365

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

Disable snmp simulator and install SC4SNMP. Set onetime_task_frequency parameter to for ex. 3, so it runs more frequent. After some time when original onetime_walk fails, bring the simulator up. Check if in ~3 minutes another onetime walk starts.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings