### PR TITLE
feat: issue a warning when assigned profile is missing

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -173,7 +173,8 @@ class Poller:
         )
 
     def process_new_job(self, entry_key, ir, profiles):
-        if ir.profile not in profiles.get("profiles"):
+        acquired_profiles = profiles.get("profiles")
+        if acquired_profiles is not None and ir.profile not in acquired_profiles:
             logger.warning(
                 f"Specified profile {ir.profile} for device {ir.host} does not exist"
             )

--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -173,6 +173,10 @@ class Poller:
         )
 
     def process_new_job(self, entry_key, ir, profiles):
+        if ir.profile not in profiles.get("profiles"):
+            logger.warning(f"Specified profile {ir.profile} for device {ir.host} does not exist")
+            return
+
         logger.debug("Adding configuration for job %s", entry_key)
         job_reference = schedule.every(int(ir.frequency_str)).seconds.do(
             scheduled_task,

--- a/splunk_connect_for_snmp_poller/manager/poller.py
+++ b/splunk_connect_for_snmp_poller/manager/poller.py
@@ -174,7 +174,9 @@ class Poller:
 
     def process_new_job(self, entry_key, ir, profiles):
         if ir.profile not in profiles.get("profiles"):
-            logger.warning(f"Specified profile {ir.profile} for device {ir.host} does not exist")
+            logger.warning(
+                f"Specified profile {ir.profile} for device {ir.host} does not exist"
+            )
             return
 
         logger.debug("Adding configuration for job %s", entry_key)


### PR DESCRIPTION
# Description

If non existing profile is assigned to device, no scheduler record is created and warning is issued.

## Type of change

Please delete options that are not relevant.

- [x] New feature


## How Has This Been Tested?

I added entry with missing profile and verified that warning was issued

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings