### PR TITLE
feat: just as for events time for metrics is assigned on SC4SNMP

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -180,6 +180,7 @@ def build_metric_data(
     fields = {
         "metric_name:" + metric_name: metric_value,
         EventField.FREQUENCY.value: ir.frequency_str,
+        EventField.TIME.value: time.time(),
     }
     if mib_enricher:
         _enrich_metric_data(mib_enricher, json_val, fields)


### PR DESCRIPTION
# Description

Time for metrics is assigned on SC4SNMP software, not Splunk.


Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

When time resolution of index is changed milliseconds are visible.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings