### PR TITLE
fix: fix issue with KeyError `metric`, double _ids in mongo and probl…

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/poller_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/poller_utilities.py
@@ -297,7 +297,11 @@ def update_enricher_config(
         )
     else:
         _update_enricher_config_for_additional_varbinds(
-            old_enricher, new_enricher, mongo, inventory_host.host, server_config
+            old_enricher,
+            new_enricher,
+            mongo,
+            return_database_id(inventory_host.host),
+            server_config,
         )
 
 

--- a/splunk_connect_for_snmp_poller/manager/task_utilities.py
+++ b/splunk_connect_for_snmp_poller/manager/task_utilities.py
@@ -87,7 +87,7 @@ async def get_translated_string(mib_server_url, var_binds, return_multimetric=Fa
     """
     logger.debug(f"Getting translation for the following var_binds: {var_binds}")
     is_metric, result = await result_without_translation(var_binds, return_multimetric)
-
+    original_varbinds = is_metric, result
     # Override the var_binds string with translated var_binds string
     try:
         data_format = _get_data_format(is_metric, return_multimetric)
@@ -107,6 +107,7 @@ async def get_translated_string(mib_server_url, var_binds, return_multimetric=Fa
                 result = await get_translation(var_binds, mib_server_url, data_format)
     except Exception:
         logger.exception("Could not perform translation. Returning original var_binds")
+        return original_varbinds
     logger.debug(f"final result -- metric: {is_metric}\n{result}")
     return result, is_metric
 
@@ -572,7 +573,6 @@ async def walk_handler_with_enricher(
         lexicographicMode=False,
     ):
         is_metric = False
-        extract_data_to_mongo(host, port, mongo_connection, var_binds)
         if _any_walk_failure_happened(
             hec_sender,
             errorIndication,

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -23,6 +23,7 @@ from pysnmp.hlapi import ObjectIdentity, ObjectType, SnmpEngine
 from splunk_connect_for_snmp_poller.manager.celery_client import app
 from splunk_connect_for_snmp_poller.manager.data.inventory_record import InventoryRecord
 from splunk_connect_for_snmp_poller.manager.hec_sender import HecSender
+from splunk_connect_for_snmp_poller.manager.realtime.oid_constant import OidConstant
 from splunk_connect_for_snmp_poller.manager.task_utilities import (
     VarbindCollection,
     build_authData,
@@ -197,7 +198,7 @@ async def snmp_polling_async(
             # Perform SNNP WALK for oid end with *
             if ir.profile[-1] == "*":
                 logger.info("Executing SNMP WALK for %s profile=%s", host, ir.profile)
-                if enricher_presence:
+                if ir.profile == OidConstant.IF_MIB:
                     await walk_handler_with_enricher(
                         ir.profile, server_config, mongo_connection, *static_parameters
                     )


### PR DESCRIPTION
…em with new hosts added

# Description

Fix of:
1.  KeyError `metric` random bug
2. Adding records to mongo with ":161" and without it
3. Weird behaviour of adding enrichers to new hosts.
Now the process is simplified, and `walk_handler_with_enricher` serves only to run enricher's walks. That means, that onetime walk won't update MIB-STATIC-DATA and whole logic is now before one_time_walk execution.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Refactor/improvement

## How Has This Been Tested?

Verified that on my local environment with adding enricher with one host, then adding another host and checking if the correct information is in enricher.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings