### PR TITLE
feat: linear backoff used while waiting for MIB

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/mib_server_client.py
+++ b/splunk_connect_for_snmp_poller/manager/mib_server_client.py
@@ -22,9 +22,6 @@ import aiohttp
 import backoff as backoff
 import requests as requests
 from aiohttp import ClientSession
-from requests.adapters import HTTPAdapter
-from urllib3.exceptions import MaxRetryError
-from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

Instead of exponential backoff we now use linear backoff of 10s


## Type of change

Please delete options that are not relevant.

- [x] Refactor/improvement


## How Has This Been Tested?

I checked how long scheduler waits when MIB is ready and result is less than 10s comparing to 90s previousely.

## Checklist

- [x] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have run pre-commit on all files before creating the PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings