### PR TITLE
Fix/deletion of index

### DIFF
--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -233,6 +233,9 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
                         # TODO delete blow debug statement
                         fields["old_metric_name:" + metric_name] = metric_value
                         continue
+                else:
+                    del fields["metric_name:" + metric_name]
+                    fields["metric_name:" + stripped] = metric_value
 
 
 def build_error_data(

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -214,7 +214,6 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
     for family in oid_families.keys():
         if metric_name.startswith("sc4snmp." + family):
             stripped = metric_name[: metric_name.index("_")]
-
             input_text = metric_name[metric_name.index("_") + 1 :]  # noqa: E203
 
             entries = oid_families[family][enricher_additional_varbinds]
@@ -226,6 +225,7 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
 
                     result = re.match(regex, input_text)
                     if result:
+                        any_regex_matched = True
                         for index, item in enumerate(names_list):
                             fields[item] = result.group(index + 1)
                         del fields["metric_name:" + metric_name]
@@ -233,9 +233,11 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
                         # TODO delete blow debug statement
                         fields["old_metric_name:" + metric_name] = metric_value
                         continue
-                else:
-                    del fields["metric_name:" + metric_name]
-                    fields["metric_name:" + stripped] = metric_value
+
+            if not any_regex_matched:
+                fields["index_number"] = input_text
+                del fields["metric_name:" + metric_name]
+                fields["metric_name:" + stripped] = metric_value
 
 
 def build_error_data(

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -215,7 +215,7 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
         if metric_name.startswith("sc4snmp." + family):
             stripped = metric_name[: metric_name.index("_")]
 
-            input_text = metric_name[metric_name.index("_") + 1:]
+            input_text = metric_name[metric_name.index("_") + 1 :]
 
             entries = oid_families[family][enricher_additional_varbinds]
             for entry in entries:

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -215,7 +215,7 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
         if metric_name.startswith("sc4snmp." + family):
             stripped = metric_name[: metric_name.index("_")]
 
-            input_text = metric_name[metric_name.index("_") + 1 :]
+            input_text = metric_name[metric_name.index("_") + 1 :]  # noqa: E203
 
             entries = oid_families[family][enricher_additional_varbinds]
             for entry in entries:

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -210,7 +210,7 @@ def build_metric_data(
 def extract_additional_properties(fields, metric_name, metric_value, server_config):
     result = multi_key_lookup(server_config, (enricher_name, enricher_oid_family))
     oid_families = result if result else []
-
+    any_regex_matched = False
     for family in oid_families.keys():
         if metric_name.startswith("sc4snmp." + family):
             stripped = metric_name[: metric_name.index("_")]

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -28,8 +28,9 @@ from splunk_connect_for_snmp_poller.manager.data.event_builder import (
 from splunk_connect_for_snmp_poller.manager.data.inventory_record import InventoryRecord
 from splunk_connect_for_snmp_poller.manager.static.mib_enricher import MibEnricher
 from splunk_connect_for_snmp_poller.manager.variables import (
+    enricher_additional_varbinds,
     enricher_name,
-    enricher_oid_family, enricher_additional_varbinds,
+    enricher_oid_family,
 )
 from splunk_connect_for_snmp_poller.utilities import multi_key_lookup
 
@@ -212,16 +213,16 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
 
     for family in oid_families.keys():
         if metric_name.startswith("sc4snmp." + family):
-            stripped = metric_name[:metric_name.index("_")]
+            stripped = metric_name[: metric_name.index("_")]
 
-            input_text = metric_name[metric_name.index("_")+1:]
+            input_text = metric_name[metric_name.index("_") + 1 :]
 
             entries = oid_families[family][enricher_additional_varbinds]
             for entry in entries:
-                if 'regex' in entry and 'names' in entry:
-                    regex = entry['regex']
-                    names = entry['names']
-                    names_list = names.split('/')
+                if "regex" in entry and "names" in entry:
+                    regex = entry["regex"]
+                    names = entry["names"]
+                    names_list = names.split("/")
 
                     result = re.match(regex, input_text)
                     if result:
@@ -229,6 +230,7 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
                             fields[item] = result.group(index + 1)
                         del fields["metric_name:" + metric_name]
                         fields["metric_name:" + stripped] = metric_value
+                        # TODO delete blow debug statement
                         fields["old_metric_name:" + metric_name] = metric_value
                         continue
 

--- a/splunk_connect_for_snmp_poller/manager/hec_sender.py
+++ b/splunk_connect_for_snmp_poller/manager/hec_sender.py
@@ -215,7 +215,7 @@ def extract_additional_properties(fields, metric_name, metric_value, server_conf
         if metric_name.startswith("sc4snmp." + family):
             stripped = metric_name[: metric_name.index("_")]
 
-            input_text = metric_name[metric_name.index("_") + 1 :]
+            input_text = metric_name[metric_name.index("_") + 1:]
 
             entries = oid_families[family][enricher_additional_varbinds]
             for entry in entries:

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -27,7 +27,7 @@ class TestAdditionalDataExtraction(TestCase):
                     "TCP-MIB": {
                         "additionalVarBinds": [
                             {
-                                "regex": "([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)",
+                                "regex": "([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)", # noqa: E501
                                 "names": "IP_one/port/IP_two/index_number",
                             }
                         ]
@@ -42,8 +42,8 @@ class TestAdditionalDataExtraction(TestCase):
                     "UDP-MIB": {
                         "additionalVarBinds": [
                             {
-                                "regex": '(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_([0-9]+)',
-                                "names": "protocol_version_one/IP_one/port_one/protocol_version_two/IP_two/index_number/port_two",
+                                "regex": '(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_([0-9]+)', # noqa: E501
+                                "names": "protocol_version_one/IP_one/port_one/protocol_version_two/IP_two/index_number/port_two", # noqa: E501
                             }
                         ]
                     },

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -77,16 +77,16 @@ class TestAdditionalDataExtraction(TestCase):
             server_config,
         )
 
-        self.assertEqual(fields['IP_one'], '192_168_0_1')
-        self.assertEqual(fields['port'], '161')
-        self.assertEqual(fields['IP_two'], '127_0_0_1')
-        self.assertEqual(fields['index_number'], '5')
+        self.assertEqual(fields["IP_one"], "192_168_0_1")
+        self.assertEqual(fields["port"], "161")
+        self.assertEqual(fields["IP_two"], "127_0_0_1")
+        self.assertEqual(fields["index_number"], "5")
 
-        self.assertEqual(fields3['protocol_version_one'], 'ipv4')
-        self.assertEqual(fields3['IP_one'], '0_0_0_0')
-        self.assertEqual(fields3['port_one'], '111')
-        self.assertEqual(fields3['protocol_version_two'], 'ipv4')
-        self.assertEqual(fields3['IP_two'], '0_0_0_0')
-        self.assertEqual(fields3['index_number'], '0')
-        self.assertEqual(fields3['port_two'], '13348')
+        self.assertEqual(fields3["protocol_version_one"], "ipv4")
+        self.assertEqual(fields3["IP_one"], "0_0_0_0")
+        self.assertEqual(fields3["port_one"], "111")
+        self.assertEqual(fields3["protocol_version_two"], "ipv4")
+        self.assertEqual(fields3["IP_two"], "0_0_0_0")
+        self.assertEqual(fields3["index_number"], "0")
+        self.assertEqual(fields3["port_two"], "13348")
 

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from unittest import TestCase
 
 from splunk_connect_for_snmp_poller.manager.hec_sender import (

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -1,0 +1,65 @@
+from unittest import TestCase
+
+from splunk_connect_for_snmp_poller.manager.hec_sender import extract_additional_properties
+
+
+class TestAdditionalDataExtraction(TestCase):
+    def test_data_extraction(self):
+        server_config = {
+            "enricher": {
+                "oidFamily": {
+                    "TCP-MIB": {
+                        "additionalVarBinds": [
+                                {
+                                    "regex": '([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)',
+                                    "names": 'IP_one/port/IP_two/index_number'
+                                }
+                        ]
+                    },
+                    "IF-MIB": {
+                        "existingVarBinds": [
+                            {"ifDescr": "interface_desc"},
+                            {"ifPhysAddress": "MAC_address"}
+                        ],
+                        "additionalVarBinds": [
+                            {"indexNum": "index_number"}
+                        ]
+                    },
+                    "UDP-MIB": {
+                        "additionalVarBinds": [
+                            {
+                                "regex": '(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_([0-9]+)',
+                                "names": 'protocol_version_one/IP_one/port_one/protocol_version_two/IP_two/index_number/port_two'
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+
+        fields = {'metric_name:sc4snmp.TCP-MIB.tcpConnLocalPort_192_168_0_1_161_127_0_0_1_5': '1111'}
+        fields2 = {'metric_name:sc4snmp.IF-MIB.ifInErrors_2': '173127'}
+        fields3 = {'metric_name:sc4snmp.UDP-MIB.udpEndpointProcess_ipv4_"0_0_0_0"_111_ipv4_"0_0_0_0"_0_13348': '123'}
+
+        extract_additional_properties(fields, 'sc4snmp.TCP-MIB.tcpConnLocalPort_192_168_0_1_161_127_0_0_1_5', '1111',
+                                      server_config)
+
+        extract_additional_properties(fields2, 'sc4snmp.IF-MIB.ifInErrors_2', '173127',
+                                      server_config)
+
+        extract_additional_properties(fields3, 'sc4snmp.UDP-MIB.udpEndpointProcess_ipv4_"0_0_0_0"_111_ipv4_"0_0_0_0"_0_13348', '123',
+                                      server_config)
+
+        self.assertEqual(fields['IP_one'], '192_168_0_1')
+        self.assertEqual(fields['port'], '161')
+        self.assertEqual(fields['IP_two'], '127_0_0_1')
+        self.assertEqual(fields['index_number'], '5')
+
+        self.assertEqual(fields3['protocol_version_one'], 'ipv4')
+        self.assertEqual(fields3['IP_one'], '0_0_0_0')
+        self.assertEqual(fields3['port_one'], '111')
+        self.assertEqual(fields3['protocol_version_two'], 'ipv4')
+        self.assertEqual(fields3['IP_two'], '0_0_0_0')
+        self.assertEqual(fields3['index_number'], '0')
+        self.assertEqual(fields3['port_two'], '13348')
+

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -89,4 +89,3 @@ class TestAdditionalDataExtraction(TestCase):
         self.assertEqual(fields3["IP_two"], "0_0_0_0")
         self.assertEqual(fields3["index_number"], "0")
         self.assertEqual(fields3["port_two"], "13348")
-

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -27,8 +27,8 @@ class TestAdditionalDataExtraction(TestCase):
                     "TCP-MIB": {
                         "additionalVarBinds": [
                             {
-                                "regex": '([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)',
-                                "names": 'IP_one/port/IP_two/index_number'
+                                "regex": "([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)",
+                                "names": "IP_one/port/IP_two/index_number",
                             }
                         ]
                     },
@@ -70,8 +70,12 @@ class TestAdditionalDataExtraction(TestCase):
             fields2, "sc4snmp.IF-MIB.ifInErrors_2", "173127", server_config
         )
 
-        extract_additional_properties(fields3, 'sc4snmp.UDP-MIB.udpEndpointProcess_ipv4_"0_0_0_0"_111_ipv4_"0_0_0_0"_0_13348', '123',
-                                      server_config)
+        extract_additional_properties(
+            fields3,
+            'sc4snmp.UDP-MIB.udpEndpointProcess_ipv4_"0_0_0_0"_111_ipv4_"0_0_0_0"_0_13348',
+            "123",
+            server_config,
+        )
 
         self.assertEqual(fields['IP_one'], '192_168_0_1')
         self.assertEqual(fields['port'], '161')

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -12,20 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2021 Splunk Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+
 from unittest import TestCase
 
 from splunk_connect_for_snmp_poller.manager.hec_sender import (

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -1,6 +1,22 @@
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from unittest import TestCase
 
-from splunk_connect_for_snmp_poller.manager.hec_sender import extract_additional_properties
+from splunk_connect_for_snmp_poller.manager.hec_sender import (
+    extract_additional_properties,
+)
 
 
 class TestAdditionalDataExtraction(TestCase):
@@ -10,26 +26,24 @@ class TestAdditionalDataExtraction(TestCase):
                 "oidFamily": {
                     "TCP-MIB": {
                         "additionalVarBinds": [
-                                {
-                                    "regex": '([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)',
-                                    "names": 'IP_one/port/IP_two/index_number'
-                                }
+                            {
+                                "regex": '([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)',
+                                "names": 'IP_one/port/IP_two/index_number'
+                            }
                         ]
                     },
                     "IF-MIB": {
                         "existingVarBinds": [
                             {"ifDescr": "interface_desc"},
-                            {"ifPhysAddress": "MAC_address"}
+                            {"ifPhysAddress": "MAC_address"},
                         ],
-                        "additionalVarBinds": [
-                            {"indexNum": "index_number"}
-                        ]
+                        "additionalVarBinds": [{"indexNum": "index_number"}],
                     },
                     "UDP-MIB": {
                         "additionalVarBinds": [
                             {
                                 "regex": '(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_([0-9]+)',
-                                "names": 'protocol_version_one/IP_one/port_one/protocol_version_two/IP_two/index_number/port_two'
+                                "names": "protocol_version_one/IP_one/port_one/protocol_version_two/IP_two/index_number/port_two",
                             }
                         ]
                     },
@@ -37,15 +51,24 @@ class TestAdditionalDataExtraction(TestCase):
             }
         }
 
-        fields = {'metric_name:sc4snmp.TCP-MIB.tcpConnLocalPort_192_168_0_1_161_127_0_0_1_5': '1111'}
-        fields2 = {'metric_name:sc4snmp.IF-MIB.ifInErrors_2': '173127'}
-        fields3 = {'metric_name:sc4snmp.UDP-MIB.udpEndpointProcess_ipv4_"0_0_0_0"_111_ipv4_"0_0_0_0"_0_13348': '123'}
+        fields = {
+            "metric_name:sc4snmp.TCP-MIB.tcpConnLocalPort_192_168_0_1_161_127_0_0_1_5": "1111"
+        }
+        fields2 = {"metric_name:sc4snmp.IF-MIB.ifInErrors_2": "173127"}
+        fields3 = {
+            'metric_name:sc4snmp.UDP-MIB.udpEndpointProcess_ipv4_"0_0_0_0"_111_ipv4_"0_0_0_0"_0_13348': "123"
+        }
 
-        extract_additional_properties(fields, 'sc4snmp.TCP-MIB.tcpConnLocalPort_192_168_0_1_161_127_0_0_1_5', '1111',
-                                      server_config)
+        extract_additional_properties(
+            fields,
+            "sc4snmp.TCP-MIB.tcpConnLocalPort_192_168_0_1_161_127_0_0_1_5",
+            "1111",
+            server_config,
+        )
 
-        extract_additional_properties(fields2, 'sc4snmp.IF-MIB.ifInErrors_2', '173127',
-                                      server_config)
+        extract_additional_properties(
+            fields2, "sc4snmp.IF-MIB.ifInErrors_2", "173127", server_config
+        )
 
         extract_additional_properties(fields3, 'sc4snmp.UDP-MIB.udpEndpointProcess_ipv4_"0_0_0_0"_111_ipv4_"0_0_0_0"_0_13348', '123',
                                       server_config)

--- a/tests/test_additional_data_extraction.py
+++ b/tests/test_additional_data_extraction.py
@@ -27,7 +27,7 @@ class TestAdditionalDataExtraction(TestCase):
                     "TCP-MIB": {
                         "additionalVarBinds": [
                             {
-                                "regex": "([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)", # noqa: E501
+                                "regex": "([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)_([0-9]+_[0-9]+_[0-9]+_[0-9]+)_([0-9]+)",  # noqa: E501
                                 "names": "IP_one/port/IP_two/index_number",
                             }
                         ]
@@ -42,8 +42,8 @@ class TestAdditionalDataExtraction(TestCase):
                     "UDP-MIB": {
                         "additionalVarBinds": [
                             {
-                                "regex": '(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_([0-9]+)', # noqa: E501
-                                "names": "protocol_version_one/IP_one/port_one/protocol_version_two/IP_two/index_number/port_two", # noqa: E501
+                                "regex": '(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_(ipv4)_"([0-9]+_[0-9]+_[0-9]+_[0-9]+)"_([0-9]+)_([0-9]+)',  # noqa: E501
+                                "names": "protocol_version_one/IP_one/port_one/protocol_version_two/IP_two/index_number/port_two",  # noqa: E501
                             }
                         ]
                     },


### PR DESCRIPTION
# Description

Deletion last index in every oidFamily when regex wasn't matched. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

## How Has This Been Tested?

I setup it on NOVA and checked if we can't see "_{index}" at the end of metrics name

## Checklist

- [ ] My commit message is [conventional](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have run pre-commit on all files before creating the PR
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings