### PR TITLE
fix: Remove unused async

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -41,17 +41,6 @@ python-versions = ">=3.6"
 vine = "5.0.0"
 
 [[package]]
-name = "asgiref"
-version = "3.4.1"
-description = "ASGI specs, helper code, and adapters"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
-
-[[package]]
 name = "async-timeout"
 version = "4.0.0"
 description = "Timeout context manager for asyncio programs"
@@ -470,7 +459,7 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.21"
+version = "3.0.22"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = false
@@ -481,11 +470,11 @@ wcwidth = "*"
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pyasn1"
@@ -738,7 +727,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "be0ed389a042178246e4e8aef6500c7bda7c56b0b1a6dce6991aa38c32784dde"
+content-hash = "49bf777320b31280d1ff21b72319801681e8b46d1eb4ce895035cee27f96cb45"
 
 [metadata.files]
 aiohttp = [
@@ -822,10 +811,6 @@ aiosignal = [
 amqp = [
     {file = "amqp-5.0.6-py3-none-any.whl", hash = "sha256:493a2ac6788ce270a2f6a765b017299f60c1998f5a8617908ee9be082f7300fb"},
     {file = "amqp-5.0.6.tar.gz", hash = "sha256:03e16e94f2b34c31f8bf1206d8ddd3ccaa4c315f7f6a1879b7b1210d229568c2"},
-]
-asgiref = [
-    {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
-    {file = "asgiref-3.4.1.tar.gz", hash = "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9"},
 ]
 async-timeout = [
     {file = "async-timeout-4.0.0.tar.gz", hash = "sha256:7d87a4e8adba8ededb52e579ce6bc8276985888913620c935094c2276fd83382"},
@@ -1212,12 +1197,12 @@ pre-commit = [
     {file = "pre_commit-2.15.0.tar.gz", hash = "sha256:3c25add78dbdfb6a28a651780d5c311ac40dd17f160eb3954a0c59da40a505a7"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.21-py3-none-any.whl", hash = "sha256:62b3d3ea5a3ccee94dc1aac018279cf64866a76837156ebe159b981c42dd20a8"},
-    {file = "prompt_toolkit-3.0.21.tar.gz", hash = "sha256:27f13ff4e4850fe8f860b77414c7880f67c6158076a7b099062cc8570f1562e5"},
+    {file = "prompt_toolkit-3.0.22-py3-none-any.whl", hash = "sha256:48d85cdca8b6c4f16480c7ce03fd193666b62b0a21667ca56b4bb5ad679d1170"},
+    {file = "prompt_toolkit-3.0.22.tar.gz", hash = "sha256:449f333dd120bd01f5d296a8ce1452114ba3a71fae7288d2f0ae2c918764fa72"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pyasn1 = [
     {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ celery = "^5.1.2"
 pymongo = {version = "^3.11.3", extras = ["srv"]} 
 jsoncomment = "^0.4.2"
 aiohttp = "^3.7.4"
-asgiref = "^3.4.1"
 backoff = "^1.11.1"
 
 [tool.poetry.dev-dependencies]

--- a/splunk_connect_for_snmp_poller/manager/tasks.py
+++ b/splunk_connect_for_snmp_poller/manager/tasks.py
@@ -15,7 +15,6 @@
 #
 import os
 
-from asgiref.sync import async_to_sync
 from celery import Task
 from celery.utils.log import get_task_logger
 from pysnmp.hlapi import ObjectIdentity, ObjectType, SnmpEngine
@@ -108,14 +107,15 @@ def sort_varbinds(varbind_list: list) -> VarbindCollection:
     casted_multikey_elements += VarbindCollection(get=get_list, bulk=bulk_list)
     return casted_multikey_elements
 
+
 class SNMPTask(Task):
-    
     def __init__(self):
         self.snmp_engine = SnmpEngine()
 
 
-@app.task(bind=True,ignore_result=True)
-def snmp_polling(self,
+@app.task(base=SNMPTask, bind=True, ignore_result=True)
+def snmp_polling(
+    self,
     ir_json: str,
     server_config,
     index,
@@ -125,14 +125,6 @@ def snmp_polling(self,
     ir = InventoryRecord.from_json(ir_json)
     logger.info(f"Got one_time_flag - {one_time_flag} with Ir - {ir.__repr__()}")
 
-    async_to_sync(snmp_polling_async)(ir, server_config, index, profiles, one_time_flag)
-
-    return f"Executing SNMP Polling for {ir.host} version={ir.version} profile={ir.profile}"
-
-
-async def snmp_polling_async(
-    ir: InventoryRecord, server_config, index, profiles, one_time_flag: str
-):
     hec_sender = HecSender(
         os.environ["OTEL_SERVER_METRICS_URL"], os.environ["OTEL_SERVER_LOGS_URL"]
     )
@@ -184,14 +176,14 @@ async def snmp_polling_async(
                 varbind_collection = sort_varbinds(var_binds)
                 logger.debug(f"Varbind collection: {varbind_collection}")
                 # Perform SNMP BULK
-                await get_snmp_data(
+                get_snmp_data(
                     varbind_collection.bulk,
                     snmp_bulk_handler,
                     *get_bulk_specific_parameters,
                     *static_parameters,
                 )
                 # Perform SNMP GET
-                await get_snmp_data(
+                get_snmp_data(
                     varbind_collection.get,
                     snmp_get_handler,
                     *get_bulk_specific_parameters,
@@ -212,7 +204,7 @@ async def snmp_polling_async(
                         host,
                         OidConstant.IF_MIB,
                     )
-                    await walk_handler_with_enricher(
+                    walk_handler_with_enricher(
                         OidConstant.IF_MIB,
                         server_config,
                         mongo_connection,
@@ -224,12 +216,12 @@ async def snmp_polling_async(
                         host,
                         ir.profile,
                     )
-                    await walk_handler(ir.profile, mongo_connection, *static_parameters)
+                    walk_handler(ir.profile, mongo_connection, *static_parameters)
             # Perform SNNP GET for an oid
             else:
                 logger.info("Executing SNMP GET for %s profile=%s", host, ir.profile)
                 prepared_profile = [ObjectType(ObjectIdentity(ir.profile))]
-                await snmp_get_handler(
+                snmp_get_handler(
                     *get_bulk_specific_parameters, *static_parameters, prepared_profile  # type: ignore
                 )
 
@@ -237,3 +229,5 @@ async def snmp_polling_async(
         logger.exception(
             f"Error occurred while executing SNMP polling for {host}, version={ir.version}, profile={ir.profile}"
         )
+
+    return f"Executing SNMP Polling for {ir.host} version={ir.version} profile={ir.profile}"


### PR DESCRIPTION
Each worker is a process or thread of its own having a task on the worker async and wait is unneeded (thread isn't cheap on Linux). To remove the thread and use and continue to re-use the SNMPEngine the task was changed to inherit from a custom class allowing the init method to be used instead.